### PR TITLE
Bootstrap speed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitvec"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993f74b4c99c1908d156b8d2e0fb6277736b0ecbd833982fd1241d39b2766a6"
+
+[[package]]
 name = "blake2b_simd"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +154,12 @@ name = "bumpalo"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad807f2fc2bf185eeb98ff3a901bd46dc5ad58163d0fa4577ba0d25674d71708"
+
+[[package]]
+name = "byte-slice-cast"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0a5e3906bcbf133e33c1d4d95afc664ad37fbdb9f6568d8043e7ea8c27d93d3"
 
 [[package]]
 name = "byteorder"
@@ -199,10 +211,12 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "console_error_panic_hook",
+ "data-bundler",
  "flate2",
  "fnv",
  "lazy_static",
  "phf 0.8.0",
+ "primitive-types",
  "regex",
  "rust-stemmers",
  "scripture-types",
@@ -260,6 +274,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "data-bundler"
 version = "0.1.0"
 dependencies = [
@@ -269,6 +289,7 @@ dependencies = [
  "phf 0.8.0",
  "phf_codegen 0.8.0",
  "phf_shared 0.8.0",
+ "primitive-types",
  "regex",
  "rust-stemmers",
  "scripture-types",
@@ -331,6 +352,18 @@ dependencies = [
  "libc",
  "redox_syscall",
  "winapi",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3367952ceb191f4ab95dd5685dc163ac539e36202f9fcfd0cb22f9f9c542fefc"
+dependencies = [
+ "byteorder",
+ "rand 0.7.3",
+ "rustc-hex",
+ "static_assertions",
 ]
 
 [[package]]
@@ -416,6 +449,15 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "impl-codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1be51a921b067b0eaca2fad532d9400041561aa922221cc65f95a85641c6bf53"
+dependencies = [
+ "parity-scale-codec",
 ]
 
 [[package]]
@@ -569,6 +611,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "parity-scale-codec"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f747c06d9f3b2ad387ac881b9667298c81b1243aa9833f086e05996937c35507"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "serde",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,6 +710,17 @@ name = "ppv-lite86"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+
+[[package]]
+name = "primitive-types"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4336f4f5d5524fa60bcbd6fe626f9223d8142a50e7053e979acdf0da41ab975"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "uint",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -989,6 +1054,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 
 [[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
 name = "ryu"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,6 +1085,7 @@ dependencies = [
  "phf 0.8.0",
  "phf_codegen 0.8.0",
  "phf_shared 0.8.0",
+ "primitive-types",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1087,6 +1159,12 @@ name = "sourcefile"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
@@ -1181,6 +1259,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "uint"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75a4cdd7b87b28840dba13c483b9a88ee6bbf16ba5c951ee1ecfcf723078e0d"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "rustc-hex",
+ "static_assertions",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 
 [[package]]
+name = "c2-chacha"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
+dependencies = [
+ "ppv-lite86",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +202,7 @@ dependencies = [
  "flate2",
  "fnv",
  "lazy_static",
+ "phf 0.8.0",
  "regex",
  "rust-stemmers",
  "scripture-types",
@@ -202,6 +212,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-test",
  "web-sys",
+ "wee_alloc",
 ]
 
 [[package]]
@@ -255,6 +266,9 @@ dependencies = [
  "bincode",
  "flate2",
  "fnv",
+ "phf 0.8.0",
+ "phf_codegen 0.8.0",
+ "phf_shared 0.8.0",
  "regex",
  "rust-stemmers",
  "scripture-types",
@@ -348,6 +362,17 @@ name = "futures"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
+
+[[package]]
+name = "getrandom"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "gzip-header"
@@ -451,6 +476,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 
 [[package]]
+name = "memory_units"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
+
+[[package]]
 name = "mime"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,8 +497,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d977de9ee851a0b16e932979515c0f3da82403183879811bc97d50bd9cc50f7"
 dependencies = [
  "mime",
- "phf",
- "phf_codegen",
+ "phf 0.7.24",
+ "phf_codegen 0.7.24",
  "unicase",
 ]
 
@@ -549,7 +580,16 @@ version = "0.7.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3da44b85f8e8dfaec21adae67f95d93244b2ecf6ad2a692320598dcc8e6dd18"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.7.24",
+]
+
+[[package]]
+name = "phf"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
+dependencies = [
+ "phf_shared 0.8.0",
 ]
 
 [[package]]
@@ -558,8 +598,18 @@ version = "0.7.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b03e85129e324ad4166b06b2c7491ae27fe3ec353af72e72cd1654c7225d517e"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.7.24",
+ "phf_shared 0.7.24",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815"
+dependencies = [
+ "phf_generator 0.8.0",
+ "phf_shared 0.8.0",
 ]
 
 [[package]]
@@ -568,8 +618,18 @@ version = "0.7.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09364cc93c159b8b06b1f4dd8a4398984503483891b0c26b867cf431fb132662"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.7.24",
  "rand 0.6.5",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
+dependencies = [
+ "phf_shared 0.8.0",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -578,9 +638,24 @@ version = "0.7.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 dependencies = [
- "siphasher",
+ "siphasher 0.2.3",
  "unicase",
 ]
+
+[[package]]
+name = "phf_shared"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
+dependencies = [
+ "siphasher 0.3.1",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 
 [[package]]
 name = "proc-macro2"
@@ -658,15 +733,29 @@ checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 dependencies = [
  "autocfg",
  "libc",
- "rand_chacha",
+ "rand_chacha 0.1.1",
  "rand_core 0.4.2",
- "rand_hc",
+ "rand_hc 0.1.0",
  "rand_isaac",
  "rand_jitter",
  "rand_os",
- "rand_pcg",
+ "rand_pcg 0.1.2",
  "rand_xorshift",
  "winapi",
+]
+
+[[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom",
+ "libc",
+ "rand_chacha 0.2.1",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
+ "rand_pcg 0.2.1",
 ]
 
 [[package]]
@@ -677,6 +766,16 @@ checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 dependencies = [
  "autocfg",
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
+dependencies = [
+ "c2-chacha",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -695,12 +794,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
 dependencies = [
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -745,6 +862,15 @@ checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 dependencies = [
  "autocfg",
  "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -885,6 +1011,9 @@ name = "scripture-types"
 version = "0.1.0"
 dependencies = [
  "fnv",
+ "phf 0.8.0",
+ "phf_codegen 0.8.0",
+ "phf_shared 0.8.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -940,6 +1069,12 @@ name = "siphasher"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
+
+[[package]]
+name = "siphasher"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83da420ee8d1a89e640d0948c646c1c088758d3a3c538f943bfa97bdac17929d"
 
 [[package]]
 name = "smallvec"
@@ -1111,6 +1246,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1231,6 +1372,18 @@ dependencies = [
  "sourcefile",
  "wasm-bindgen",
  "wasm-bindgen-webidl",
+]
+
+[[package]]
+name = "wee_alloc"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "memory_units",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
+dependencies = [
+ "byteorder",
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,6 +188,7 @@ checksum = "498d20a7aaf62625b9bf26e637cf7736417cde1d0c99f1d04d1170229a85cf87"
 name = "client"
 version = "0.1.0"
 dependencies = [
+ "bincode",
  "console_error_panic_hook",
  "flate2",
  "lazy_static",
@@ -241,6 +252,7 @@ dependencies = [
 name = "data-bundler"
 version = "0.1.0"
 dependencies = [
+ "bincode",
  "flate2",
  "regex",
  "rust-stemmers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,7 @@ dependencies = [
  "data-bundler",
  "flate2",
  "fnv",
+ "indices",
  "lazy_static",
  "phf 0.8.0",
  "primitive-types",
@@ -458,6 +459,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1be51a921b067b0eaca2fad532d9400041561aa922221cc65f95a85641c6bf53"
 dependencies = [
  "parity-scale-codec",
+]
+
+[[package]]
+name = "indices"
+version = "0.1.0"
+dependencies = [
+ "phf 0.8.0",
+ "primitive-types",
+ "scripture-types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,7 @@ dependencies = [
  "bincode",
  "console_error_panic_hook",
  "flate2",
+ "fnv",
  "lazy_static",
  "regex",
  "rust-stemmers",
@@ -201,7 +202,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-test",
  "web-sys",
- "wee_alloc",
 ]
 
 [[package]]
@@ -254,6 +254,7 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "flate2",
+ "fnv",
  "regex",
  "rust-stemmers",
  "scripture-types",
@@ -329,6 +330,12 @@ dependencies = [
  "libc",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 
 [[package]]
 name = "fuchsia-cprng"
@@ -442,12 +449,6 @@ name = "memchr"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
-
-[[package]]
-name = "memory_units"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "mime"
@@ -883,6 +884,7 @@ checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 name = "scripture-types"
 version = "0.1.0"
 dependencies = [
+ "fnv",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1229,18 +1231,6 @@ dependencies = [
  "sourcefile",
  "wasm-bindgen",
  "wasm-bindgen-webidl",
-]
-
-[[package]]
-name = "wee_alloc"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
-dependencies = [
- "cfg-if",
- "libc",
- "memory_units",
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "client",
   "data-bundler",
   "scripture-types",
+  "indices",
 ]
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,3 @@ members = [
 [profile.release]
 # Tell `rustc` to optimize for small code size.
 opt-level = "s"
-

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -23,6 +23,7 @@ serde_derive = "1.0.103"
 serde_json = "1.0.42"
 bincode = "1.2.1"
 fnv = "1.0.6"
+phf = "0.8.0"
 
 scripture-types = { path = "../scripture-types" }
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1.0.103", features = ["derive"] }
 serde_derive = "1.0.103"  
 serde_json = "1.0.42"
 bincode = "1.2.1"
+fnv = "1.0.6"
 
 scripture-types = { path = "../scripture-types" }
 
@@ -49,7 +50,9 @@ wasm-bindgen-test = "0.2"
 # link time optimizations
 lto = true
 # Tell `rustc` to optimize for small code size.
-opt-level = "s"
+# opt-level = "s"
+# Tell `rustc` to optimize for small code speed.
+opt-level = 3
 
 [dependencies.web-sys]
 version = "0.3"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -53,7 +53,7 @@ opt-level = "s"
 [dependencies.web-sys]
 version = "0.3"
 features = [
- "console",
+ "console", "Performance", "Window"
 ]
 
 [dependencies.wasm-bindgen]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -28,6 +28,7 @@ primitive-types = "0.6.2"
 
 scripture-types = { path = "../scripture-types" }
 data-bundler = { path = "../data-bundler" }
+indices = { path = "../indices" }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
@@ -54,7 +55,7 @@ wasm-bindgen-test = "0.2"
 lto = true
 # Tell `rustc` to optimize for small code size.
 # opt-level = "s"
-# Tell `rustc` to optimize for small code speed.
+# Tell `rustc` to optimize for code speed.
 opt-level = 3
 
 [dependencies.web-sys]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -24,8 +24,10 @@ serde_json = "1.0.42"
 bincode = "1.2.1"
 fnv = "1.0.6"
 phf = "0.8.0"
+primitive-types = "0.6.2"
 
 scripture-types = { path = "../scripture-types" }
+data-bundler = { path = "../data-bundler" }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -21,6 +21,7 @@ rust-stemmers = "1.2.0"
 serde = { version = "1.0.103", features = ["derive"] }
 serde_derive = "1.0.103"  
 serde_json = "1.0.42"
+bincode = "1.2.1"
 
 scripture-types = { path = "../scripture-types" }
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -59,7 +59,7 @@ lazy_static! {
         adserde(BIN_DOCTRINE_AND_COVENANTS);
     static ref PEARL_OF_GREAT_PRICE: PearlOfGreatPrice = adserde(BIN_PEARL_OF_GREAT_PRICE);
 
-    static ref VERSE_PATHS_INDEX: VersePathsIndex = scripture_types::paths_to_verse_paths_index(&PHF_PATHS_INDEX);
+    static ref VERSE_PATHS_INDEX: VersePathsIndex = scripture_types::paths_to_verse_paths_index(&indices::PHF_PATHS_INDEX);
 
     static ref STEMMER: rust_stemmers::Stemmer = Stemmer::create(Algorithm::English);
     static ref RE_VERSE_CHARS: Regex = Regex::new(r"[^A-Za-z0-9\sæ\-]").unwrap();
@@ -106,8 +106,8 @@ fn make_link(verse_path: &scripture_types::VersePath) -> String {
     format!("{}/{}", BASE_URL, url_slug)
 }
 
-fn extract_highlights((indices, lengths): &(U256, u128)) -> Vec<(u16, u8)> {
-    data_bundler::unpack_indices(*indices).iter().cloned().zip(data_bundler::unpack_lengths(*lengths)).collect()
+fn extract_highlights((start_indices, lengths): &(U256, u128)) -> Vec<(u16, u8)> {
+    data_bundler::unpack_indices(*start_indices).iter().cloned().zip(data_bundler::unpack_lengths(*lengths)).collect()
 }
 
 fn highlight_matches(text: &String, highlights: &Vec<(u16, u8)>) -> String {
@@ -162,8 +162,8 @@ pub fn bootstrap_searcher() {
 
     log!(
         "words: {:?}, paths: {:?}, verse_paths: {:?}",
-        (&PHF_WORDS_INDEX).len(),
-        (&PHF_PATHS_INDEX).len(),
+        (&indices::PHF_WORDS_INDEX).len(),
+        (&indices::PHF_PATHS_INDEX).len(),
         num_verse_paths,
     );
 
@@ -244,7 +244,7 @@ pub fn full_match_search(search_term_raw: String, search_preferences_js: JsValue
     }
 
     log!("accessing paths index");
-    let paths_index = &PHF_PATHS_INDEX;
+    let paths_index = &indices::PHF_PATHS_INDEX;
 
     let search_term = &make_splittable(&search_term_raw.to_lowercase());
 
@@ -257,7 +257,7 @@ pub fn full_match_search(search_term_raw: String, search_preferences_js: JsValue
         search_stems
             .iter()
             .fold(FnvHashMap::default(), |mut matching_index, term| {
-                if let Some(v) = PHF_WORDS_INDEX.get(term.as_str()) {
+                if let Some(v) = indices::PHF_WORDS_INDEX.get(term.as_str()) {
                     matching_index.insert(term.to_string(), v);
                 }
                 matching_index
@@ -308,10 +308,7 @@ pub fn full_match_search(search_term_raw: String, search_preferences_js: JsValue
     let sorted_verses: Vec<&String> = verses.iter().map(|(_, text)| text).collect();
 
     let t_1 = web_sys::window().unwrap().performance().unwrap().now();
-    log!("text search time: {:?}", t_1 - t_0);
+    log!("search time: {:?}", t_1 - t_0);
     JsValue::from_serde(&sorted_verses).unwrap()
 }
-
-include!("../../data-bundler/data/codegen-paths-index.rs");
-include!("../../data-bundler/data/codegen-words-index.rs");
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -35,36 +35,35 @@ macro_rules! log {
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
-static STR_OLD_TESTAMENT: &'static str =
-    include_str!("../../data-bundler/data/old-testament.json");
-static STR_NEW_TESTAMENT: &'static str =
-    include_str!("../../data-bundler/data/new-testament.json");
-static STR_BOOK_OF_MORMON: &'static str =
-    include_str!("../../data-bundler/data/book-of-mormon.json");
-static STR_DOCTRINE_AND_COVENANTS: &'static str =
-    include_str!("../../data-bundler/data/doctrine-and-covenants.json");
-static STR_PEARL_OF_GREAT_PRICE: &'static str =
-    include_str!("../../data-bundler/data/pearl-of-great-price.json");
-static STR_WORDS_INDEX: &'static str =
-    include_str!("../../data-bundler/data/words-index.json");
-static STR_PATHS_INDEX: &'static str =
-    include_str!("../../data-bundler/data/paths-index.json");
+static BIN_OLD_TESTAMENT: &'static [u8] =
+    include_bytes!("../../data-bundler/data/old-testament.json.bin");
+static BIN_NEW_TESTAMENT: &'static [u8] =
+    include_bytes!("../../data-bundler/data/new-testament.json.bin");
+static BIN_BOOK_OF_MORMON: &'static [u8] =
+    include_bytes!("../../data-bundler/data/book-of-mormon.json.bin");
+static BIN_DOCTRINE_AND_COVENANTS: &'static [u8] =
+    include_bytes!("../../data-bundler/data/doctrine-and-covenants.json.bin");
+static BIN_PEARL_OF_GREAT_PRICE: &'static [u8] =
+    include_bytes!("../../data-bundler/data/pearl-of-great-price.json.bin");
+static BIN_WORDS_INDEX: &'static [u8] =
+    include_bytes!("../../data-bundler/data/words-index.json.bin");
+static BIN_PATHS_INDEX: &'static [u8] =
+    include_bytes!("../../data-bundler/data/paths-index.json.bin");
 
 
 static BASE_URL: &'static str = "https://www.churchofjesuschrist.org/study/scriptures";
 
-// TODO: Figure out to do this one, at compile time.
 lazy_static! {
-    static ref BOOK_OF_MORMON: BookOfMormon = adserde(STR_BOOK_OF_MORMON);
-    static ref OLD_TESTAMENT: OldTestament = adserde(STR_OLD_TESTAMENT);
-    static ref NEW_TESTAMENT: NewTestament = adserde(STR_NEW_TESTAMENT);
+    static ref BOOK_OF_MORMON: BookOfMormon = adserde(BIN_BOOK_OF_MORMON);
+    static ref OLD_TESTAMENT: OldTestament = adserde(BIN_OLD_TESTAMENT);
+    static ref NEW_TESTAMENT: NewTestament = adserde(BIN_NEW_TESTAMENT);
     static ref DOCTRINE_AND_COVENANTS: DoctrineAndCovenants =
-        adserde(STR_DOCTRINE_AND_COVENANTS);
-    static ref PEARL_OF_GREAT_PRICE: PearlOfGreatPrice = adserde(STR_PEARL_OF_GREAT_PRICE);
+        adserde(BIN_DOCTRINE_AND_COVENANTS);
+    static ref PEARL_OF_GREAT_PRICE: PearlOfGreatPrice = adserde(BIN_PEARL_OF_GREAT_PRICE);
 
 
-    static ref WORDS_INDEX: WordsIndex = adserde(STR_WORDS_INDEX);
-    static ref PATHS_INDEX: PathsIndex = adserde(STR_PATHS_INDEX);
+    static ref WORDS_INDEX: WordsIndex = adserde(BIN_WORDS_INDEX);
+    static ref PATHS_INDEX: PathsIndex = adserde(BIN_PATHS_INDEX);
     static ref VERSE_PATHS_INDEX: VersePathsIndex = scripture_types::paths_to_verse_paths_index(&*PATHS_INDEX);
 
     static ref STEMMER: rust_stemmers::Stemmer = Stemmer::create(Algorithm::English);
@@ -139,10 +138,10 @@ fn format_verse(
     )
 }
 
-pub fn adserde<T: serde::de::DeserializeOwned + serde::ser::Serialize>(s: &'static str) -> T {
+pub fn adserde<T: serde::de::DeserializeOwned + serde::ser::Serialize>(s: &'static [u8]) -> T {
     let t_0 = web_sys::window().unwrap().performance().unwrap().now();
 
-    let data: T = serde_json::from_str(s).unwrap();
+    let data: T = bincode::deserialize(s).unwrap();
     let t_1 = web_sys::window().unwrap().performance().unwrap().now();
     log!("PARSING STRING: {:?}", t_1 - t_0);
     data

--- a/client/src/preferences.rs
+++ b/client/src/preferences.rs
@@ -50,11 +50,11 @@ pub fn make_empty_preferences() -> SearchPreferences {
             pogp: true,
         },
         included_books: IncludedBooks {
-            ot: vec![],
-            nt: vec![],
-            bom: vec![],
-            dc: (1, 1),
-            pogp: vec![],
+            ot: vec![String::from("Genesis")],
+            nt: vec![String::from("Matthew")],
+            bom: vec![String::from("1 Nephi")],
+            dc: (1, 20),
+            pogp: vec![String::from("Abraham")],
         },
     }
 }

--- a/client/src/preferences.rs
+++ b/client/src/preferences.rs
@@ -33,7 +33,7 @@ pub struct IncludedBooks {
     pub ot: Vec<String>,
     pub nt: Vec<String>,
     pub bom: Vec<String>,
-    pub dc: (u64, u64),
+    pub dc: (u8, u8),
     pub pogp: Vec<String>,
 }
 

--- a/client/web/package.json
+++ b/client/web/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "rm dist/* || true && NODE_ENV=production webpack --config webpack.config.js",
-    "start": "webpack-dev-server",
+    "start": "webpack-dev-server --host 0.0.0.0",
     "test": "jest"
   },
   "repository": {

--- a/client/web/src/Form.tsx
+++ b/client/web/src/Form.tsx
@@ -57,15 +57,23 @@ export default function Form({
           flex: '0 0 auto',
         }}
       />
-      { typeof resultCount === 'number' && <span style={{
-        position: 'absolute',
-        left: '100%',
-        whiteSpace: 'nowrap',
-        alignSelf: 'center',
+      { false && typeof resultCount === 'number' && <div style={{
+        // position: 'absolute',
+        // left: '100%',
+        // whiteSpace: 'nowrap',
+        // alignSelf: 'center',
       }}>
         {resultCount} results
-      </span>}
+      </div>}
     </div>
+      { typeof resultCount === 'number' && <div style={{
+        // position: 'absolute',
+        // left: '100%',
+        // whiteSpace: 'nowrap',
+        // alignSelf: 'center',
+      }}>
+        {resultCount} results
+      </div>}
     {preferencesOpen &&
       <Preferences
         preferences={preferences}

--- a/client/web/src/Preferences.tsx
+++ b/client/web/src/Preferences.tsx
@@ -508,7 +508,7 @@ export default function Preferences({
           right: '-9px',
           padding: '4px 7px',
           borderRadius: '100%',
-          fontWeight: '800',
+          fontWeight: 800,
         }}
         onClick={hidePreferences}
       >&#10799;</button>

--- a/data-bundler/Cargo.toml
+++ b/data-bundler/Cargo.toml
@@ -18,5 +18,6 @@ fnv = "1.0.6"
 phf = "0.8.0"
 phf_shared = "0.8.0"
 phf_codegen = "0.8.0"
+primitive-types = "0.6.2"
 
 scripture-types = { path = "../scripture-types" }

--- a/data-bundler/Cargo.toml
+++ b/data-bundler/Cargo.toml
@@ -13,5 +13,6 @@ rust-stemmers = "1.2.0"
 serde = { version = "1.0.103", features = ["derive"] }
 serde_derive = "1.0.103"  
 serde_json = "1.0.42"
+bincode = "1.2.1"
 
 scripture-types = { path = "../scripture-types" }

--- a/data-bundler/Cargo.toml
+++ b/data-bundler/Cargo.toml
@@ -14,5 +14,6 @@ serde = { version = "1.0.103", features = ["derive"] }
 serde_derive = "1.0.103"  
 serde_json = "1.0.42"
 bincode = "1.2.1"
+fnv = "1.0.6"
 
 scripture-types = { path = "../scripture-types" }

--- a/data-bundler/Cargo.toml
+++ b/data-bundler/Cargo.toml
@@ -15,5 +15,8 @@ serde_derive = "1.0.103"
 serde_json = "1.0.42"
 bincode = "1.2.1"
 fnv = "1.0.6"
+phf = "0.8.0"
+phf_shared = "0.8.0"
+phf_codegen = "0.8.0"
 
 scripture-types = { path = "../scripture-types" }

--- a/data-bundler/src/lib.rs
+++ b/data-bundler/src/lib.rs
@@ -145,7 +145,6 @@ pub fn pack_indices_arr(indices: &Vec<u16>) -> [u64;4] {
 
     let new_num = num >> 64 << 64;
     num_arr[3] = (num - new_num).as_u64();
-    num = new_num;
 
     num_arr
 }

--- a/data-bundler/src/main.rs
+++ b/data-bundler/src/main.rs
@@ -4,6 +4,7 @@ use std::io::BufReader;
 use std::io::BufWriter;
 use std::io::Read;
 use std::path::Path;
+use std::io::Write;
 
 use data_bundler;
 
@@ -55,10 +56,11 @@ pub fn copy_minified<T: serde::de::DeserializeOwned + serde::ser::Serialize>(
     let parsed: T = serde_json::from_str(&unparsed).unwrap();
 
     let mut dest = dest_folder.clone();
-    dest.push(format!("{}", file_name));
+    dest.push(format!("{}.bin", file_name));
 
     let mut f = BufWriter::new(File::create(dest).unwrap());
-    serde_json::to_writer(&mut f, &parsed).unwrap();
+    f.write(&bincode::serialize(&parsed).unwrap()).unwrap();
+    f.flush().unwrap();
 
     parsed
 }
@@ -69,12 +71,13 @@ pub fn write_minified<T: serde::ser::Serialize>(
     file_name: &str,
 ) -> () {
     let mut dest = dest_folder.clone();
-    dest.push(format!("{}", file_name));
+    dest.push(format!("{}.bin", file_name));
 
     println!("writing {}", file_name);
 
     let mut f = BufWriter::new(File::create(dest).unwrap());
-    serde_json::to_writer(&mut f, &data).unwrap();
+    f.write(&bincode::serialize(&data).unwrap()).unwrap();
+    f.flush().unwrap();
 }
 
 fn main() {

--- a/data-bundler/src/main.rs
+++ b/data-bundler/src/main.rs
@@ -164,7 +164,7 @@ fn main() {
 
     writeln!(
         &mut f_codegen,
-        "static PHF_PATHS_INDEX: phf::Map<u16, scripture_types::VersePath> = \n{};\n",
+        "pub static PHF_PATHS_INDEX: phf::Map<u16, scripture_types::VersePath> = \n{};\n",
         paths_index_phf.build(),
     ).unwrap();
 
@@ -201,7 +201,7 @@ fn main() {
 
     writeln!(
         &mut f_codegen_words_index,
-        "static PHF_WORDS_INDEX: phf::Map<&str, phf::Map<u16, (U256,u128)>> = \n{};\n",
+        "pub static PHF_WORDS_INDEX: phf::Map<&str, phf::Map<u16, (U256,u128)>> = \n{};\n",
         words_index_phf.build(),
     ).unwrap();
 }

--- a/data-bundler/src/main.rs
+++ b/data-bundler/src/main.rs
@@ -5,9 +5,6 @@ use std::io::BufWriter;
 use std::io::Read;
 use std::path::Path;
 
-use flate2::write::GzEncoder;
-use flate2::Compression;
-use std::io::prelude::*;
 use data_bundler;
 
 #[cfg(windows)]
@@ -58,14 +55,10 @@ pub fn copy_minified<T: serde::de::DeserializeOwned + serde::ser::Serialize>(
     let parsed: T = serde_json::from_str(&unparsed).unwrap();
 
     let mut dest = dest_folder.clone();
-    dest.push(format!("{}.{}", file_name, "gz"));
+    dest.push(format!("{}", file_name));
 
-    let mut encoder = GzEncoder::new(Vec::new(), Compression::best());
-    serde_json::to_writer(&mut encoder, &parsed).unwrap();
-
-    let mut f_gzipped = BufWriter::new(File::create(dest).unwrap());
-    let gzipped = encoder.finish().unwrap();
-    f_gzipped.write(&gzipped).unwrap();
+    let mut f = BufWriter::new(File::create(dest).unwrap());
+    serde_json::to_writer(&mut f, &parsed).unwrap();
 
     parsed
 }
@@ -76,16 +69,12 @@ pub fn write_minified<T: serde::ser::Serialize>(
     file_name: &str,
 ) -> () {
     let mut dest = dest_folder.clone();
-    dest.push(format!("{}.{}", file_name, "gz"));
+    dest.push(format!("{}", file_name));
 
     println!("writing {}", file_name);
 
-    let mut encoder = GzEncoder::new(Vec::new(), Compression::best());
-    serde_json::to_writer(&mut encoder, data).unwrap();
-
-    let mut f_gzipped = BufWriter::new(File::create(dest).unwrap());
-    let gzipped = encoder.finish().unwrap();
-    f_gzipped.write(&gzipped).unwrap();
+    let mut f = BufWriter::new(File::create(dest).unwrap());
+    serde_json::to_writer(&mut f, &data).unwrap();
 }
 
 fn main() {

--- a/data-bundler/src/main.rs
+++ b/data-bundler/src/main.rs
@@ -132,10 +132,11 @@ fn main() {
     println!("Minifying done!\n");
 
     println!("Building indices:");
-    let (words_index, paths_index) = data_bundler::build_index(&ot, &nt, &bom, &dc, &pogp);
+    let (words_index, words_index_no_highlighting, paths_index) = data_bundler::build_index(&ot, &nt, &bom, &dc, &pogp);
     println!("Index building done!\n");
     println!("total word stems: {}", words_index.len());
     println!("total paths: {}", paths_index.len());
     write_minified(&paths_index, &dest_folder, "paths-index.json");
     write_minified(&words_index, &dest_folder, "words-index.json");
+    write_minified(&words_index_no_highlighting, &dest_folder, "words-index-no-highlights.json");
 }

--- a/indices/Cargo.toml
+++ b/indices/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "indices"
+version = "0.1.0"
+authors = ["neallred <neallred@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+phf = "0.8.0"
+primitive-types = "0.6.2"
+scripture-types = { path = "../scripture-types" }
+
+[profile.release]
+lto = true
+opt-level = 3

--- a/indices/src/lib.rs
+++ b/indices/src/lib.rs
@@ -1,0 +1,6 @@
+extern crate phf;
+use primitive_types::U256;
+use scripture_types::{VersePath};
+
+include!("../../data-bundler/data/codegen-paths-index.rs");
+include!("../../data-bundler/data/codegen-words-index.rs");

--- a/scripture-types/Cargo.toml
+++ b/scripture-types/Cargo.toml
@@ -14,6 +14,7 @@ fnv = "1.0.6"
 phf = "0.8.0"
 phf_codegen = "0.8.0"
 phf_shared  = "0.8.0"
+primitive-types = "0.6.2"
 
 [dependencies.wasm-bindgen]
 version = "0.2"

--- a/scripture-types/Cargo.toml
+++ b/scripture-types/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 serde = { version = "1.0.103", features = ["derive"] }
 serde_json = "1.0.42"
 serde_derive = "1.0.103"  
+fnv = "1.0.6"
 
 [dependencies.wasm-bindgen]
 version = "0.2"

--- a/scripture-types/Cargo.toml
+++ b/scripture-types/Cargo.toml
@@ -11,6 +11,9 @@ serde = { version = "1.0.103", features = ["derive"] }
 serde_json = "1.0.42"
 serde_derive = "1.0.103"  
 fnv = "1.0.6"
+phf = "0.8.0"
+phf_codegen = "0.8.0"
+phf_shared  = "0.8.0"
 
 [dependencies.wasm-bindgen]
 version = "0.2"

--- a/scripture-types/src/lib.rs
+++ b/scripture-types/src/lib.rs
@@ -2,54 +2,16 @@ extern crate serde;
 extern crate serde_derive;
 extern crate serde_json;
 extern crate phf;
+use primitive_types::U256;
 
 use serde::{Deserialize, Serialize};
 use fnv::FnvHashMap;
 
-#[derive(Serialize, Deserialize, Debug, Hash, Clone)]
-pub enum ArrWrap {
-    A1([(u16, u8); 1]),
-    A2([(u16, u8); 2]),
-    A3([(u16, u8); 3]),
-    A4([(u16, u8); 4]),
-    A5([(u16, u8); 5]),
-    A6([(u16, u8); 6]),
-    A7([(u16, u8); 7]),
-    A8([(u16, u8); 8]),
-    A9([(u16, u8); 9]),
-    A10([(u16, u8); 10]),
-    A11([(u16, u8); 11]),
-    A12([(u16, u8); 12]),
-    A13([(u16, u8); 13]),
-    A14([(u16, u8); 14]),
-    A15([(u16, u8); 15]),
-    A16([(u16, u8); 16]),
-    A17([(u16, u8); 17]),
-    A18([(u16, u8); 18]),
-    A19([(u16, u8); 19]),
-    A20([(u16, u8); 20]),
-    A21([(u16, u8); 21]),
-    A22([(u16, u8); 22]),
-//     The longest number of highlights is A22.
-//     The biggest number of highlight index is 1168.
-//     Exclude all other possibilities to take up the least amount of memory possible
-//     (Need this to run on low end devices).
-//     A23([(u16, u8); 23]),
-//     A24([(u16, u8); 24]),
-//     A25([(u16, u8); 25]),
-//     A26([(u16, u8); 26]),
-//     A27([(u16, u8); 27]),
-//     A28([(u16, u8); 28]),
-//     A29([(u16, u8); 29]),
-//     A30([(u16, u8); 30]),
-//     A31([(u16, u8); 31]),
-//     A32([(u16, u8); 32]),
-}
-
-pub type WordsIndex = FnvHashMap<String, FnvHashMap<u16, FnvHashMap<usize, usize>>>;
+pub type WordsIndex = FnvHashMap<String, FnvHashMap<u16, Vec<(usize, usize)>>>;
 pub type PathsIndex = FnvHashMap<u16, VersePath>;
-pub type PhfPathsIndex = phf::Map<u16, VersePath>;
 pub type VersePathsIndex = FnvHashMap<VersePath, u16>;
+pub type PhfPathsIndex = phf::Map<u16, VersePath>;
+pub type PhfWordsIndex = phf::Map<&'static str, phf::Map<u16, (U256, u128)>>;
 
 pub fn paths_to_verse_paths_index(paths: &PhfPathsIndex) -> VersePathsIndex {
     paths

--- a/scripture-types/src/lib.rs
+++ b/scripture-types/src/lib.rs
@@ -1,21 +1,59 @@
 extern crate serde;
 extern crate serde_derive;
 extern crate serde_json;
+extern crate phf;
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use fnv::FnvHashMap;
-use fnv::FnvHashSet;
-use std::collections::HashSet;
 
-pub type WordsIndex = FnvHashMap<String, FnvHashMap<u32, FnvHashMap<usize, usize>>>;
-pub type WordsIndexNoHighlights = FnvHashMap<String, FnvHashSet<u32>>;
-pub type PathsIndex = FnvHashMap<u32, VersePath>;
-pub type VersePathsIndex = FnvHashMap<VersePath, u32>;
+#[derive(Serialize, Deserialize, Debug, Hash, Clone)]
+pub enum ArrWrap {
+    A1([(u16, u8); 1]),
+    A2([(u16, u8); 2]),
+    A3([(u16, u8); 3]),
+    A4([(u16, u8); 4]),
+    A5([(u16, u8); 5]),
+    A6([(u16, u8); 6]),
+    A7([(u16, u8); 7]),
+    A8([(u16, u8); 8]),
+    A9([(u16, u8); 9]),
+    A10([(u16, u8); 10]),
+    A11([(u16, u8); 11]),
+    A12([(u16, u8); 12]),
+    A13([(u16, u8); 13]),
+    A14([(u16, u8); 14]),
+    A15([(u16, u8); 15]),
+    A16([(u16, u8); 16]),
+    A17([(u16, u8); 17]),
+    A18([(u16, u8); 18]),
+    A19([(u16, u8); 19]),
+    A20([(u16, u8); 20]),
+    A21([(u16, u8); 21]),
+    A22([(u16, u8); 22]),
+//     The longest number of highlights is A22.
+//     The biggest number of highlight index is 1168.
+//     Exclude all other possibilities to take up the least amount of memory possible
+//     (Need this to run on low end devices).
+//     A23([(u16, u8); 23]),
+//     A24([(u16, u8); 24]),
+//     A25([(u16, u8); 25]),
+//     A26([(u16, u8); 26]),
+//     A27([(u16, u8); 27]),
+//     A28([(u16, u8); 28]),
+//     A29([(u16, u8); 29]),
+//     A30([(u16, u8); 30]),
+//     A31([(u16, u8); 31]),
+//     A32([(u16, u8); 32]),
+}
 
-pub fn paths_to_verse_paths_index(paths: &PathsIndex) -> VersePathsIndex {
+pub type WordsIndex = FnvHashMap<String, FnvHashMap<u16, FnvHashMap<usize, usize>>>;
+pub type PathsIndex = FnvHashMap<u16, VersePath>;
+pub type PhfPathsIndex = phf::Map<u16, VersePath>;
+pub type VersePathsIndex = FnvHashMap<VersePath, u16>;
+
+pub fn paths_to_verse_paths_index(paths: &PhfPathsIndex) -> VersePathsIndex {
     paths
-        .iter()
+        .entries()
         .fold(
             FnvHashMap::default(),
             |mut acc, (k, v)| {
@@ -27,11 +65,11 @@ pub fn paths_to_verse_paths_index(paths: &PathsIndex) -> VersePathsIndex {
 
 #[derive(Serialize, Deserialize, Debug, Hash, Eq, PartialEq, Clone)]
 pub enum VersePath {
-    PathBoM(usize, usize, usize),
-    PathOT(usize, usize, usize),
-    PathNT(usize, usize, usize),
-    PathPOGP(usize, usize, usize),
-    PathDC(usize, usize), // section verse
+    PathBoM(u8, u8, u16),
+    PathOT(u8, u8, u16),
+    PathNT(u8, u8, u16),
+    PathPOGP(u8, u8, u16),
+    PathDC(u8, u16), // section verse
 }
 
 #[derive(Serialize, Deserialize)]
@@ -41,12 +79,12 @@ pub struct Verse {
     pub reference: String,
     pub subheading: Option<String>,
     pub text: String,
-    pub verse: u64,
+    pub verse: u16,
 }
 
 #[derive(Serialize, Deserialize)]
 pub struct Chapter {
-    pub chapter: u64,
+    pub chapter: u8,
     pub heading: Option<String>,
     pub note: Option<String>,
     pub reference: String,
@@ -78,7 +116,7 @@ pub struct Book {
 // structs
 #[derive(Serialize, Deserialize)]
 pub struct Section {
-    pub section: u64,
+    pub section: u8,
     pub reference: String,
     pub verses: Vec<Verse>,
     pub signature: Option<String>,
@@ -93,7 +131,7 @@ pub struct BookOfMormon {
     pub testimonies: Vec<Testimony>,
     pub title: String,
     pub title_page: TitlePage,
-    pub version: u64,
+    pub version: u8,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -119,7 +157,7 @@ pub struct DoctrineAndCovenants {
     pub subsubtitle: String,
     pub subtitle: String,
     pub title: String,
-    pub version: u64,
+    pub version: u8,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -136,7 +174,7 @@ pub struct NewTestament {
     pub lds_slug: String,
     pub title: String,
     pub title_page: NewTestamentTitlePage,
-    pub version: u64,
+    pub version: u8,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -146,7 +184,7 @@ pub struct OldTestament {
     pub lds_slug: String,
     pub the_end: String,
     pub title: String,
-    pub version: u64,
+    pub version: u8,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -156,5 +194,5 @@ pub struct PearlOfGreatPrice {
     pub lds_slug: String,
     pub subtitle: String,
     pub title: String,
-    pub version: u64,
+    pub version: u8,
 }

--- a/scripture-types/src/lib.rs
+++ b/scripture-types/src/lib.rs
@@ -4,17 +4,20 @@ extern crate serde_json;
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-// use std::collections::HashSet;
+use fnv::FnvHashMap;
+use fnv::FnvHashSet;
+use std::collections::HashSet;
 
-pub type WordsIndex = HashMap<String, HashMap<u32, Vec<(usize, usize)>>>;
-pub type PathsIndex = HashMap<u32, VersePath>;
-pub type VersePathsIndex = HashMap<VersePath, u32>;
+pub type WordsIndex = FnvHashMap<String, FnvHashMap<u32, FnvHashMap<usize, usize>>>;
+pub type WordsIndexNoHighlights = FnvHashMap<String, FnvHashSet<u32>>;
+pub type PathsIndex = FnvHashMap<u32, VersePath>;
+pub type VersePathsIndex = FnvHashMap<VersePath, u32>;
 
 pub fn paths_to_verse_paths_index(paths: &PathsIndex) -> VersePathsIndex {
     paths
         .iter()
         .fold(
-            HashMap::new(),
+            FnvHashMap::default(),
             |mut acc, (k, v)| {
                 acc.insert(v.clone(), *k);
                 acc


### PR DESCRIPTION
Bootstrapping on slow devices is very slow, even once the bundle is downloaded. About 60 seconds. Using a phf map for the indices means we don't need to decode or build the indices on the phone, shaving off about 45 seconds on low end devices.

Placing the phf map compilation in its own crate keeps the client package build speed fast.